### PR TITLE
Feature: ページ分割と経験値反映の改善

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -117,9 +117,9 @@ const Board: React.FC<BoardProps> = ({ openAddTaskModal, onEditTask, onDeleteTas
       onDragEnd={handleDragEnd}
     >
       <div className="flex flex-col h-full">
-        {/* Horizontal scrollable container */}
+        {/* Centered horizontal scrollable container */}
         <div className="flex-1 overflow-x-auto overflow-y-hidden">
-          <div className="flex gap-6 p-6 min-w-max h-full">
+          <div className="flex gap-6 p-6 min-w-max h-full justify-center">
             <Column 
               title="クエスト" 
               emoji="🗺️" 

--- a/src/components/JourneyPage.tsx
+++ b/src/components/JourneyPage.tsx
@@ -28,7 +28,7 @@ interface JourneyPageProps {
 }
 
 const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
-  const { clearedTasks, resetJourney } = useJourneyStore();
+  const { clearedTasks, resetJourney, addClearedTask } = useJourneyStore();
   const { claimAllExp, columnOrder, tasks } = useTaskStore();
   const [currentSlime, setCurrentSlime] = useState(1);
   const [nextGoal, setNextGoal] = useState(10);
@@ -114,7 +114,19 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
   };
 
   const handleClaimAllExp = () => {
+    // 完了タスクを取得してJourneyStoreに追加
+    const completedTasks = columnOrder.done
+      .map(id => tasks[id])
+      .filter(task => task && !task.expClaimed);
+
+    // 各タスクをJourneyStoreに追加
+    completedTasks.forEach(task => {
+      addClearedTask(task);
+    });
+
+    // TaskStoreから経験値を反映（タスクを削除）
     const claimedCount = claimAllExp();
+    
     if (claimedCount > 0) {
       // 進化演出のトリガー
       const newTotal = totalCleared + claimedCount;

--- a/src/components/JourneyPage.tsx
+++ b/src/components/JourneyPage.tsx
@@ -1,0 +1,288 @@
+import React, { useState } from 'react';
+import { ArrowLeft, Star, RefreshCw, History } from 'lucide-react';
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+} from 'chart.js';
+import { useJourneyStore } from '../store/useJourneyStore';
+import { useTaskStore } from '../store/useTaskStore';
+import PastTasksModal from './PastTasksModal';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+interface JourneyPageProps {
+  onNavigateToBoard: () => void;
+}
+
+const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
+  const { clearedTasks, resetJourney } = useJourneyStore();
+  const { claimAllExp, columnOrder, tasks } = useTaskStore();
+  const [currentSlime, setCurrentSlime] = useState(1);
+  const [nextGoal, setNextGoal] = useState(10);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [isEvolving, setIsEvolving] = useState(false);
+  const [previousSlime, setPreviousSlime] = useState(1);
+  const [showPastTasks, setShowPastTasks] = useState(false);
+
+  React.useEffect(() => {
+    const total = Object.values(clearedTasks).reduce((sum, record) => sum + record.count, 0);
+    const newSlimeLevel = total >= 100 ? 5 
+                       : total >= 50 ? 4 
+                       : total >= 20 ? 3 
+                       : total >= 10 ? 2 
+                       : 1;
+
+    if (newSlimeLevel !== currentSlime) {
+      setPreviousSlime(currentSlime);
+      setCurrentSlime(newSlimeLevel);
+      setIsEvolving(true);
+      setTimeout(() => setIsEvolving(false), 2000);
+    }
+
+    const goals = [10, 20, 50, 100];
+    const next = goals.find(n => n > total) ?? Infinity;
+    setNextGoal(next);
+  }, [clearedTasks, currentSlime]);
+
+  const last7Days = Array.from({ length: 7 }, (_, i) => {
+    const date = new Date();
+    date.setDate(date.getDate() - i);
+    return date.toISOString().split('T')[0];
+  }).reverse();
+
+  const chartData = {
+    labels: last7Days.map(date => date.split('-').slice(1).join('/')),
+    datasets: [{
+      label: 'クリアしたタスク',
+      data: last7Days.map(date => clearedTasks[date]?.count || 0),
+      backgroundColor: 'rgba(54, 162, 235, 0.5)',
+      borderColor: 'rgba(54, 162, 235, 1)',
+      borderWidth: 1
+    }]
+  };
+
+  const chartOptions = {
+    responsive: true,
+    plugins: {
+      legend: {
+        display: false
+      },
+      title: {
+        display: true,
+        text: '過去7日間のクリア数',
+        font: {
+          family: "'Press Start 2P', 'DotGothic16', sans-serif",
+          size: 14
+        }
+      }
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        ticks: {
+          stepSize: 1
+        }
+      }
+    }
+  };
+
+  const totalCleared = Object.values(clearedTasks).reduce((sum, record) => sum + record.count, 0);
+  const completedTasksCount = columnOrder.done
+    .map(id => tasks[id])
+    .filter(task => task && !task.expClaimed).length;
+
+  const handleResetClick = () => {
+    setShowConfirm(true);
+  };
+
+  const handleConfirmReset = () => {
+    resetJourney();
+    setShowConfirm(false);
+  };
+
+  const handleClaimAllExp = () => {
+    const claimedCount = claimAllExp();
+    if (claimedCount > 0) {
+      // 進化演出のトリガー
+      const newTotal = totalCleared + claimedCount;
+      const newSlimeLevel = newTotal >= 100 ? 5 
+                         : newTotal >= 50 ? 4 
+                         : newTotal >= 20 ? 3 
+                         : newTotal >= 10 ? 2 
+                         : 1;
+
+      if (newSlimeLevel !== currentSlime) {
+        setPreviousSlime(currentSlime);
+        setCurrentSlime(newSlimeLevel);
+        setIsEvolving(true);
+        setTimeout(() => setIsEvolving(false), 2000);
+      }
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-screen bg-slate-50">
+      {/* Header */}
+      <header className="bg-royal-blue text-white p-4 shadow-md">
+        <div className="container mx-auto flex items-center">
+          <button
+            onClick={onNavigateToBoard}
+            className="flex items-center bg-blue-700 hover:bg-blue-800 transition-colors duration-200 text-white px-3 py-2 rounded mr-4"
+          >
+            <ArrowLeft size={18} className="mr-1" />
+            タスクボードに戻る
+          </button>
+          <div className="flex items-center">
+            <img 
+              src="/quest-board-logo.svg" 
+              alt="Quest Board Logo" 
+              className="w-8 h-8 mr-3"
+            />
+            <h1 className="text-2xl font-pixel">旅の記録</h1>
+          </div>
+        </div>
+      </header>
+
+      {/* Main Content */}
+      <main className="flex-1 overflow-y-auto p-6">
+        <div className="container mx-auto max-w-4xl">
+          <div className="bg-white rounded-xl shadow-lg p-8 space-y-8">
+            
+            {/* スライム表示エリア */}
+            <div className="text-center">
+              <div className="flex justify-between items-center mb-6">
+                <h2 className="text-3xl font-pixel text-gray-800">冒険者の成長</h2>
+                <div className="flex gap-3">
+                  <button
+                    onClick={() => setShowPastTasks(true)}
+                    className="p-3 text-blue-500 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all duration-200"
+                    title="過去のタスクを表示"
+                  >
+                    <History size={24} />
+                  </button>
+                  <button
+                    onClick={handleResetClick}
+                    className="p-3 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all duration-200"
+                    title="記録をリセット"
+                  >
+                    <RefreshCw size={24} />
+                  </button>
+                </div>
+              </div>
+
+              {/* スライム進化演出エリア */}
+              <div className="relative flex justify-center mb-8">
+                {isEvolving && (
+                  <>
+                    <div className="absolute inset-0 flex items-center justify-center">
+                      <div className="absolute">
+                        <div className="animate-sparkle absolute -top-12 -left-12">✨</div>
+                        <div className="animate-sparkle absolute -top-12 left-12">✨</div>
+                        <div className="animate-sparkle absolute top-12 -left-12">✨</div>
+                        <div className="animate-sparkle absolute top-12 left-12">✨</div>
+                        <div className="animate-sparkle absolute -top-8 right-16">⭐</div>
+                        <div className="animate-sparkle absolute bottom-8 -right-16">🌟</div>
+                      </div>
+                    </div>
+                    <img 
+                      src={`/slime_${previousSlime}.jpg`}
+                      alt={`Level ${previousSlime} Slime`}
+                      className="w-48 h-48 object-contain rounded-lg shadow-md opacity-50 absolute"
+                    />
+                  </>
+                )}
+                <img 
+                  src={`/slime_${currentSlime}.jpg`} 
+                  alt={`Level ${currentSlime} Slime`}
+                  className={`w-48 h-48 object-contain rounded-lg shadow-md ${isEvolving ? 'animate-bounce' : ''}`}
+                />
+              </div>
+
+              <div className="space-y-4 mb-8">
+                <p className="font-pixel text-2xl text-gray-700">
+                  これまでに{totalCleared}個のタスクをクリア！
+                </p>
+                {nextGoal !== Infinity && (
+                  <p className="font-pixel text-lg text-blue-600">
+                    あと{nextGoal - totalCleared}個で進化！
+                  </p>
+                )}
+                
+                {/* 経験値反映ボタン */}
+                {completedTasksCount > 0 && (
+                  <div className="bg-yellow-50 border-2 border-yellow-200 rounded-xl p-6 mt-6">
+                    <p className="font-pixel text-lg text-yellow-800 mb-4">
+                      {completedTasksCount}個の完了タスクがあります
+                    </p>
+                    <button
+                      onClick={handleClaimAllExp}
+                      className="bg-yellow-500 hover:bg-yellow-600 text-white font-pixel px-8 py-4 rounded-lg transition-all duration-200 flex items-center gap-3 mx-auto text-lg"
+                    >
+                      <Star size={24} />
+                      経験値を反映する
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* グラフエリア */}
+            <div className="bg-gray-50 rounded-xl p-6">
+              <div className="h-80">
+                <Bar data={chartData} options={chartOptions} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+
+      {/* 確認ダイアログ */}
+      {showConfirm && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded-lg shadow-xl max-w-sm w-full mx-4">
+            <h3 className="text-xl font-pixel text-gray-800 mb-4">
+              記録をリセットしますか？
+            </h3>
+            <p className="text-gray-600 mb-6">
+              これまでのタスククリア記録が全て消去されます。この操作は取り消せません。
+            </p>
+            <div className="flex justify-end space-x-4">
+              <button
+                onClick={() => setShowConfirm(false)}
+                className="px-4 py-2 text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+              >
+                キャンセル
+              </button>
+              <button
+                onClick={handleConfirmReset}
+                className="px-4 py-2 bg-red-500 text-white hover:bg-red-600 rounded-lg transition-colors"
+              >
+                リセット
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <PastTasksModal
+        isOpen={showPastTasks}
+        onClose={() => setShowPastTasks(false)}
+      />
+    </div>
+  );
+};
+
+export default JourneyPage;

--- a/src/components/MiniSlime.tsx
+++ b/src/components/MiniSlime.tsx
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react';
+import { useJourneyStore } from '../store/useJourneyStore';
+
+interface MiniSlimeProps {
+  onClick: () => void;
+}
+
+const MiniSlime: React.FC<MiniSlimeProps> = ({ onClick }) => {
+  const { clearedTasks } = useJourneyStore();
+  const [currentSlime, setCurrentSlime] = useState(1);
+  const [isHovered, setIsHovered] = useState(false);
+
+  useEffect(() => {
+    const total = Object.values(clearedTasks).reduce((sum, record) => sum + record.count, 0);
+    const newSlimeLevel = total >= 100 ? 5 
+                       : total >= 50 ? 4 
+                       : total >= 20 ? 3 
+                       : total >= 10 ? 2 
+                       : 1;
+    setCurrentSlime(newSlimeLevel);
+  }, [clearedTasks]);
+
+  return (
+    <div className="fixed bottom-6 right-6 z-40">
+      <button
+        onClick={onClick}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        className={`
+          relative bg-white rounded-full p-3 shadow-lg border-2 border-blue-200
+          transition-all duration-300 hover:shadow-xl hover:scale-110
+          ${isHovered ? 'animate-bounce' : ''}
+        `}
+        title="旅の記録を見る"
+      >
+        <img 
+          src={`/slime_${currentSlime}.jpg`} 
+          alt={`Level ${currentSlime} Slime`}
+          className="w-16 h-16 object-contain rounded-full"
+        />
+        
+        {/* ホバー時のツールチップ */}
+        {isHovered && (
+          <div className="absolute bottom-full right-0 mb-2 bg-gray-800 text-white text-sm px-3 py-2 rounded-lg whitespace-nowrap">
+            旅の記録を見る
+            <div className="absolute top-full right-4 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-800"></div>
+          </div>
+        )}
+        
+        {/* レベル表示 */}
+        <div className="absolute -top-1 -right-1 bg-blue-500 text-white text-xs font-bold rounded-full w-6 h-6 flex items-center justify-center">
+          {currentSlime}
+        </div>
+      </button>
+    </div>
+  );
+};
+
+export default MiniSlime;

--- a/src/components/MiniSlime.tsx
+++ b/src/components/MiniSlime.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useJourneyStore } from '../store/useJourneyStore';
+import { useTaskStore } from '../store/useTaskStore';
 
 interface MiniSlimeProps {
   onClick: () => void;
@@ -7,6 +8,7 @@ interface MiniSlimeProps {
 
 const MiniSlime: React.FC<MiniSlimeProps> = ({ onClick }) => {
   const { clearedTasks } = useJourneyStore();
+  const { columnOrder, tasks } = useTaskStore();
   const [currentSlime, setCurrentSlime] = useState(1);
   const [isHovered, setIsHovered] = useState(false);
 
@@ -20,6 +22,11 @@ const MiniSlime: React.FC<MiniSlimeProps> = ({ onClick }) => {
     setCurrentSlime(newSlimeLevel);
   }, [clearedTasks]);
 
+  // クリアボードのタスク数を計算
+  const completedTasksCount = columnOrder.done
+    .map(id => tasks[id])
+    .filter(task => task && !task.expClaimed).length;
+
   return (
     <div className="fixed bottom-6 right-6 z-40">
       <button
@@ -31,7 +38,7 @@ const MiniSlime: React.FC<MiniSlimeProps> = ({ onClick }) => {
           transition-all duration-300 hover:shadow-xl hover:scale-110
           ${isHovered ? 'animate-bounce' : ''}
         `}
-        title="旅の記録を見る"
+        title={`旅の記録を見る (完了タスク: ${completedTasksCount}個)`}
       >
         <img 
           src={`/slime_${currentSlime}.jpg`} 
@@ -43,13 +50,18 @@ const MiniSlime: React.FC<MiniSlimeProps> = ({ onClick }) => {
         {isHovered && (
           <div className="absolute bottom-full right-0 mb-2 bg-gray-800 text-white text-sm px-3 py-2 rounded-lg whitespace-nowrap">
             旅の記録を見る
+            <br />
+            完了タスク: {completedTasksCount}個
             <div className="absolute top-full right-4 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-800"></div>
           </div>
         )}
         
-        {/* レベル表示 */}
-        <div className="absolute -top-1 -right-1 bg-blue-500 text-white text-xs font-bold rounded-full w-6 h-6 flex items-center justify-center">
-          {currentSlime}
+        {/* クリアタスク数表示 */}
+        <div className={`
+          absolute -top-1 -right-1 text-white text-xs font-bold rounded-full w-6 h-6 flex items-center justify-center
+          ${completedTasksCount > 0 ? 'bg-red-500 animate-pulse' : 'bg-gray-400'}
+        `}>
+          {completedTasksCount}
         </div>
       </button>
     </div>

--- a/src/components/TaskBoard.tsx
+++ b/src/components/TaskBoard.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import Header from './Header';
+import Board from './Board';
+import ReportModal from './ReportModal';
+import TemplateEditorModal from './TemplateEditorModal';
+import TaskEditorModal from './TaskEditorModal';
+import MiniSlime from './MiniSlime';
+import { useTaskStore } from '../store/useTaskStore';
+import { TaskStatus, Task } from '../types/task';
+
+interface TaskBoardProps {
+  onNavigateToJourney: () => void;
+}
+
+const TaskBoard: React.FC<TaskBoardProps> = ({ onNavigateToJourney }) => {
+  const [reportModalOpen, setReportModalOpen] = useState(false);
+  const [templateModalOpen, setTemplateModalOpen] = useState(false);
+  const [taskEditorModalOpen, setTaskEditorModalOpen] = useState(false);
+  const [taskEditorStatus, setTaskEditorStatus] = useState<TaskStatus>('backlog');
+  const [editingTask, setEditingTask] = useState<Task | undefined>(undefined);
+  const [taskEditorMode, setTaskEditorMode] = useState<'add' | 'edit'>('add');
+  
+  const { addTask, updateTask, removeTask } = useTaskStore();
+
+  const openAddTaskModal = (status: TaskStatus = 'backlog') => {
+    setTaskEditorStatus(status);
+    setTaskEditorMode('add');
+    setEditingTask(undefined);
+    setTaskEditorModalOpen(true);
+  };
+
+  const openEditTaskModal = (task: Task) => {
+    setTaskEditorStatus(task.status);
+    setTaskEditorMode('edit');
+    setEditingTask(task);
+    setTaskEditorModalOpen(true);
+  };
+
+  const handleTaskSave = (title: string, description: string) => {
+    if (taskEditorMode === 'add') {
+      addTask(title, description, taskEditorStatus);
+    } else if (taskEditorMode === 'edit' && editingTask) {
+      updateTask(editingTask.id, { title, description });
+    }
+  };
+
+  const handleTaskDelete = (taskId: string) => {
+    removeTask(taskId);
+  };
+
+  return (
+    <div className="flex flex-col h-screen bg-slate-50">
+      <Header 
+        openReportModal={() => setReportModalOpen(true)}
+        openTemplateModal={() => setTemplateModalOpen(true)}
+      />
+      
+      <main className="flex-1 overflow-hidden p-4">
+        <div className="container mx-auto h-full">
+          <Board 
+            openAddTaskModal={openAddTaskModal}
+            onEditTask={openEditTaskModal}
+            onDeleteTask={handleTaskDelete}
+          />
+        </div>
+      </main>
+      
+      <footer className="bg-slate-100 border-t border-slate-200 py-2 px-4">
+        <div className="container mx-auto flex justify-center items-center space-x-6 text-xs text-slate-400">
+          <button
+            onClick={() => window.open('https://github.com/kozuke/quest-like-simple-kanban', '_blank', 'noopener,noreferrer')}
+            className="hover:text-slate-600 transition-colors duration-200"
+          >
+            GitHub
+          </button>
+          <span className="text-slate-300">|</span>
+          <button
+            onClick={onNavigateToJourney}
+            className="hover:text-slate-600 transition-colors duration-200"
+          >
+            旅の記録
+          </button>
+          <span className="text-slate-300">|</span>
+          <span 
+            className="text-slate-400 font-mono text-xs"
+            title="Command+K (Mac) または Ctrl+K でタスク作成"
+          >
+            ⌘K / Ctrl+K
+          </span>
+        </div>
+      </footer>
+
+      {/* ミニスライム表示 */}
+      <MiniSlime onClick={onNavigateToJourney} />
+      
+      <ReportModal 
+        isOpen={reportModalOpen} 
+        onClose={() => setReportModalOpen(false)}
+        openTemplateModal={() => {
+          setReportModalOpen(false);
+          setTemplateModalOpen(true);
+        }}
+      />
+      
+      <TemplateEditorModal
+        isOpen={templateModalOpen}
+        onClose={() => setTemplateModalOpen(false)}
+      />
+
+      <TaskEditorModal
+        isOpen={taskEditorModalOpen}
+        onClose={() => setTaskEditorModalOpen(false)}
+        onSave={handleTaskSave}
+        status={taskEditorStatus}
+        task={editingTask}
+        mode={taskEditorMode}
+      />
+    </div>
+  );
+};
+
+export default TaskBoard;

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -1,10 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Pencil, Trash2, Copy } from 'lucide-react';
 import { Task } from '../types/task';
-import { useTaskStore } from '../store/useTaskStore';
-import { useJourneyStore } from '../store/useJourneyStore';
 
 interface TaskCardProps {
   task: Task;
@@ -14,10 +12,6 @@ interface TaskCardProps {
 }
 
 const TaskCard: React.FC<TaskCardProps> = ({ task, onEdit, onDelete, onCopy }) => {
-  const [isDisappearing, setIsDisappearing] = useState(false);
-  const { claimExp } = useTaskStore();
-  const { addClearedTask } = useJourneyStore();
-  
   const {
     attributes,
     listeners,
@@ -48,38 +42,6 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onEdit, onDelete, onCopy }) =
     onCopy(task.id);
   };
 
-  const handleClaimExp = async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setIsDisappearing(true);
-    
-    // Add task to journey record
-    addClearedTask(task);
-    
-    // Wait for the animation to complete
-    await new Promise(resolve => setTimeout(resolve, 800));
-    
-    claimExp(task.id);
-    onDelete(task.id);
-  };
-
-  if (isDisappearing) {
-    return (
-      <div 
-        className="relative bg-white/95 backdrop-blur-sm border border-gray-200/60 p-4 rounded-xl shadow-md mb-3 animate-disappear"
-      >
-        <div className="absolute inset-0 flex items-center justify-center">
-          <div className="animate-sparkle">✨</div>
-        </div>
-        <div className="opacity-0">
-          <h3 className="font-pixel text-gray-900 mb-2">{task.title}</h3>
-          {task.description && (
-            <p className="font-pixel text-gray-700 text-sm mt-2">{task.description}</p>
-          )}
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div 
       ref={setNodeRef} 
@@ -93,19 +55,6 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onEdit, onDelete, onCopy }) =
           {task.title}
         </h3>
         <div className="flex space-x-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex-shrink-0">
-          {task.status === 'done' && !task.expClaimed && (
-            <button 
-              onClick={handleClaimExp}
-              className="p-1.5 hover:bg-yellow-50 rounded-lg transition-all duration-200"
-              title="経験値を獲得"
-            >
-              <img 
-                src="/exp_icon.png" 
-                alt="経験値を獲得" 
-                className="w-4 h-4"
-              />
-            </button>
-          )}
           <button 
             onClick={handleEdit}
             className="p-1.5 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all duration-200"

--- a/src/store/useTaskStore.ts
+++ b/src/store/useTaskStore.ts
@@ -1,7 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { Task, TaskStatus, TaskStore } from '../types/task';
-import { useJourneyStore } from './useJourneyStore';
 import { playAddTaskSound, playDeleteSound, playMoveSound, playFanfareSound } from '../utils/audio';
 
 export const useTaskStore = create<TaskStore>()(
@@ -171,9 +170,7 @@ export const useTaskStore = create<TaskStore>()(
       },
       
       claimAllExp: () => {
-        const { addClearedTask } = useJourneyStore.getState();
-        
-        let totalExp = 0;
+        let claimedCount = 0;
         
         set((state) => {
           const doneTasks = state.columnOrder.done
@@ -182,14 +179,11 @@ export const useTaskStore = create<TaskStore>()(
           
           if (doneTasks.length === 0) return state;
           
-          // Add tasks to journey record and calculate total exp
-          doneTasks.forEach(task => {
-            addClearedTask(task);
-          });
+          claimedCount = doneTasks.length;
           
           playFanfareSound();
           
-          // Remove claimed tasks
+          // Remove claimed tasks from the board
           const newTasks = { ...state.tasks };
           doneTasks.forEach(task => {
             delete newTasks[task.id];
@@ -204,7 +198,7 @@ export const useTaskStore = create<TaskStore>()(
           };
         });
         
-        return totalExp;
+        return claimedCount;
       }
     }),
     {


### PR DESCRIPTION
### 目的

タスク管理とゲーミフィケーション要素を分離し、ユーザー体験の向上と経験値反映の明確化を図ります。

### 変更点

1.  **ページ分割の導入**
    *   `App.tsx` が `TaskBoard` (メインのカンバンボード)、`JourneyPage` (ゲーミフィケーションダッシュボード)、`TermsOfService` 間のナビゲーションを管理するようになりました。
    *   `TaskBoard.tsx` は、カンバンボード、ヘッダー、フッターをカプセル化します。
    *   `JourneyPage.tsx` は、スライムダッシュボード、タスク履歴、経験値反映のための専用ページとして新設されました。

2.  **経験値反映ロジックの変更**
    *   タスクが「クリア」に移動しても、経験値は自動的に反映されなくなりました。
    *   `JourneyPage.tsx` に「経験値を反映する」ボタンが追加されました。
    *   このボタンをクリックすると、`useTaskStore` から `claimAllExp` アクションがトリガーされ（ボードからタスクを削除）、同時にクリアされたタスクが `useJourneyStore` に追加されます。
    *   これにより、進化アニメーションと経験値反映が `JourneyPage` に集約されます。

3.  **ミニスライム表示の追加**
    *   `TaskBoard` の右下隅に新しい `MiniSlime.tsx` コンポーネントが追加されました。
    *   現在のスライムレベルと、「クリア」カラムにあり、まだ経験値が反映されていないタスクの数がバッジで表示されます。
    *   ミニスライムをクリックすると `JourneyPage` に遷移します。

4.  **タスクボードのレイアウト調整**
    *   `Board.tsx` 内のカンバンカラムが水平方向に中央揃えになりました。

5.  **`TaskCard` からの経験値獲得ボタンの削除**
    *   経験値獲得ボタンと関連ロジックは、経験値反映を `JourneyPage` に集約するため、`TaskCard.tsx` から削除されました。
