### PR TITLE
feat: ボードと旅の記録画面のUI/UX改善、タスク復元機能の追加

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -117,9 +117,9 @@ const Board: React.FC<BoardProps> = ({ openAddTaskModal, onEditTask, onDeleteTas
       onDragEnd={handleDragEnd}
     >
       <div className="flex flex-col h-full">
-        {/* Centered horizontal scrollable container */}
-        <div className="flex-1 overflow-x-auto overflow-y-hidden">
-          <div className="flex gap-6 p-6 min-w-max h-full justify-center">
+        {/* 横スクロール完全無効、3カラム固定レイアウト */}
+        <div className="flex-1 overflow-hidden">
+          <div className="flex gap-4 p-4 h-full">
             <Column 
               title="クエスト" 
               emoji="🗺️" 

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -41,17 +41,17 @@ const Column: React.FC<ColumnProps> = ({ title, emoji, status, tasks, openAddTas
   };
 
   return (
-    <div className="flex-1 min-w-[280px] max-w-[360px] h-full flex flex-col rounded-xl border shadow-lg overflow-hidden backdrop-blur-sm bg-white/10">
-      <div className={`p-4 border-b border-inherit bg-white/90 backdrop-blur-sm flex items-center justify-between ${columnBg[status]}`}>
-        <div className="flex items-center gap-3">
-          <span className={`inline-flex items-center justify-center h-10 w-10 rounded-full ${emojiStyles[status]} font-pixel text-lg`}>
+    <div className="flex-1 h-full flex flex-col rounded-xl border shadow-lg overflow-hidden backdrop-blur-sm bg-white/10">
+      <div className={`p-4 border-b border-inherit bg-white/90 backdrop-blur-sm flex items-center justify-between ${columnBg[status]} flex-shrink-0`}>
+        <div className="flex items-center gap-3 min-w-0 flex-1">
+          <span className={`inline-flex items-center justify-center h-10 w-10 rounded-full ${emojiStyles[status]} font-pixel text-lg flex-shrink-0`}>
             {emoji}
           </span>
-          <h2 className="font-pixel text-lg font-medium text-gray-800">{title}</h2>
+          <h2 className="font-pixel text-lg font-medium text-gray-800 truncate">{title}</h2>
         </div>
         <button
           onClick={handleAddTask}
-          className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all duration-200"
+          className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-all duration-200 flex-shrink-0"
         >
           <PlusCircle size={20} />
         </button>

--- a/src/components/JourneyPage.tsx
+++ b/src/components/JourneyPage.tsx
@@ -131,7 +131,7 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
         text: '🗓️ 過去7日間のクリア数',
         font: {
           family: "'Press Start 2P', 'DotGothic16', sans-serif",
-          size: 10
+          size: 8
         },
         color: '#374151'
       }
@@ -143,7 +143,7 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
           stepSize: 1,
           font: {
             family: "'Press Start 2P', 'DotGothic16', sans-serif",
-            size: 8
+            size: 6
           }
         },
         grid: {
@@ -154,7 +154,7 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
         ticks: {
           font: {
             family: "'Press Start 2P', 'DotGothic16', sans-serif",
-            size: 8
+            size: 6
           }
         },
         grid: {
@@ -250,26 +250,26 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
         </div>
       </header>
 
-      {/* Main Content - 横並び時は縦スクロール無効、縦並び時は有効 */}
+      {/* Main Content - 横並び時は縦スクロール完全無効、縦並び時は有効 */}
       <main className="flex-1 lg:overflow-hidden overflow-y-auto">
-        <div className="container mx-auto max-w-7xl p-4 lg:p-6 h-full">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-6 lg:h-full">
+        <div className="container mx-auto max-w-7xl p-3 lg:p-4 h-full">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 lg:gap-4 lg:h-full">
             
             {/* 左側: スライム主役エリア */}
-            <div className={`${backgroundTheme.bg} rounded-xl overflow-hidden shadow-2xl relative min-h-[500px] lg:h-full flex flex-col`}>
+            <div className={`${backgroundTheme.bg} rounded-xl overflow-hidden shadow-2xl relative min-h-[450px] lg:h-full flex flex-col`}>
               
               {/* メインコンテンツ */}
-              <div className="relative z-10 flex flex-col h-full p-4 lg:p-6 text-center">
+              <div className="relative z-10 flex flex-col h-full p-3 lg:p-4 text-center">
                 
                 {/* ヘッダー情報 */}
-                <div className="flex-shrink-0 mb-4 lg:mb-6">
-                  <h2 className="text-2xl lg:text-3xl xl:text-4xl font-pixel text-white drop-shadow-lg mb-2">
+                <div className="flex-shrink-0 mb-3 lg:mb-4">
+                  <h2 className="text-xl lg:text-2xl xl:text-3xl font-pixel text-white drop-shadow-lg mb-1 lg:mb-2">
                     Lv.{currentSlime} スライム
                   </h2>
-                  <p className="text-base lg:text-lg xl:text-xl font-pixel text-white/90 drop-shadow-md mb-1">
+                  <p className="text-sm lg:text-base xl:text-lg font-pixel text-white/90 drop-shadow-md mb-1">
                     {backgroundTheme.title}
                   </p>
-                  <p className="text-sm lg:text-base xl:text-lg font-pixel text-white/80 drop-shadow-md">
+                  <p className="text-xs lg:text-sm xl:text-base font-pixel text-white/80 drop-shadow-md">
                     {backgroundTheme.scene}の住人
                   </p>
                 </div>
@@ -290,7 +290,7 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
                       <img 
                         src={`/slime_${previousSlime}.jpg`}
                         alt={`Level ${previousSlime} Slime`}
-                        className="w-48 h-48 lg:w-64 lg:h-64 xl:w-80 xl:h-80 object-contain drop-shadow-2xl opacity-50 absolute animate-evolution"
+                        className="w-40 h-40 lg:w-48 lg:h-48 xl:w-56 xl:h-56 object-contain drop-shadow-2xl opacity-50 absolute animate-evolution"
                       />
                     )}
                     
@@ -298,7 +298,7 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
                     <img 
                       src={`/slime_${currentSlime}.jpg`} 
                       alt={`Level ${currentSlime} Slime`}
-                      className={`w-48 h-48 lg:w-64 lg:h-64 xl:w-80 xl:h-80 object-contain drop-shadow-2xl transition-all duration-300 
+                      className={`w-40 h-40 lg:w-48 lg:h-48 xl:w-56 xl:h-56 object-contain drop-shadow-2xl transition-all duration-300 
                                  group-hover:scale-105 ${isEvolving ? 'animate-evolution' : ''} ${slimeAction}`}
                     />
                   </div>
@@ -306,21 +306,21 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
                 
                 {/* 進捗情報 */}
                 <div className="flex-shrink-0 w-full max-w-md mx-auto">
-                  <div className="space-y-2 lg:space-y-3 mb-3 lg:mb-4">
-                    <p className="font-pixel text-lg lg:text-xl xl:text-2xl text-white drop-shadow-lg">
+                  <div className="space-y-1 lg:space-y-2 mb-2 lg:mb-3">
+                    <p className="font-pixel text-base lg:text-lg xl:text-xl text-white drop-shadow-lg">
                       {totalCleared}個のタスクをクリア！
                     </p>
                     {nextGoal !== Infinity && (
-                      <p className="font-pixel text-xs lg:text-sm xl:text-lg text-white/90 drop-shadow-md">
+                      <p className="font-pixel text-xs lg:text-sm xl:text-base text-white/90 drop-shadow-md">
                         次の進化まで: {nextGoal - totalCleared}個
                       </p>
                     )}
                   </div>
                   
                   {/* 進捗バー */}
-                  <div className="bg-white/30 rounded-full h-2 lg:h-3 xl:h-4 backdrop-blur-sm border border-white/40 mb-3 lg:mb-4">
+                  <div className="bg-white/30 rounded-full h-2 lg:h-3 backdrop-blur-sm border border-white/40 mb-2 lg:mb-3">
                     <div 
-                      className="bg-gradient-to-r from-yellow-400 to-orange-500 h-2 lg:h-3 xl:h-4 rounded-full transition-all duration-500 shadow-inner"
+                      className="bg-gradient-to-r from-yellow-400 to-orange-500 h-2 lg:h-3 rounded-full transition-all duration-500 shadow-inner"
                       style={{ 
                         width: nextGoal !== Infinity ? `${((totalCleared % (nextGoal === 10 ? 10 : nextGoal === 20 ? 10 : nextGoal === 50 ? 30 : 50)) / (nextGoal === 10 ? 10 : nextGoal === 20 ? 10 : nextGoal === 50 ? 30 : 50)) * 100}%` : '100%'
                       }}
@@ -329,15 +329,15 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
                   
                   {/* 経験値反映ボタン */}
                   {completedTasksCount > 0 && (
-                    <div className="bg-white/20 backdrop-blur-sm border border-white/30 rounded-xl p-3 lg:p-4 w-full">
-                      <p className="font-pixel text-xs lg:text-sm xl:text-base text-white drop-shadow-md mb-2 lg:mb-3">
+                    <div className="bg-white/20 backdrop-blur-sm border border-white/30 rounded-xl p-2 lg:p-3 w-full">
+                      <p className="font-pixel text-xs lg:text-sm text-white drop-shadow-md mb-2">
                         {completedTasksCount}個の完了タスクがあります
                       </p>
                       <button
                         onClick={handleClaimAllExp}
-                        className="bg-yellow-500 hover:bg-yellow-600 text-white font-pixel px-3 py-2 lg:px-4 lg:py-2 xl:px-6 xl:py-3 rounded-lg transition-all duration-200 flex items-center gap-2 mx-auto text-xs lg:text-sm xl:text-base shadow-lg hover:shadow-xl transform hover:scale-105"
+                        className="bg-yellow-500 hover:bg-yellow-600 text-white font-pixel px-3 py-1 lg:px-4 lg:py-2 rounded-lg transition-all duration-200 flex items-center gap-1 lg:gap-2 mx-auto text-xs lg:text-sm shadow-lg hover:shadow-xl transform hover:scale-105"
                       >
-                        <Star size={14} className="lg:w-4 lg:h-4 xl:w-5 xl:h-5" />
+                        <Star size={12} className="lg:w-4 lg:h-4" />
                         経験値を反映する
                       </button>
                     </div>
@@ -351,76 +351,76 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
               
               {/* 統計エリアヘッダー - インラインスタイルで強制的に背景色を適用 */}
               <div 
-                className="text-white p-4 lg:p-6 flex-shrink-0"
+                className="text-white p-3 lg:p-4 flex-shrink-0"
                 style={{
                   background: 'linear-gradient(to right, #3b82f6, #9333ea)',
                   backgroundColor: '#3b82f6'
                 }}
               >
                 <div className="flex justify-between items-center">
-                  <h3 className="text-xl lg:text-2xl font-pixel text-white">冒険の記録</h3>
+                  <h3 className="text-lg lg:text-xl font-pixel text-white">冒険の記録</h3>
                   <div className="flex gap-2">
                     <button
                       onClick={() => setShowPastTasks(true)}
-                      className="p-2 text-white/80 hover:text-white hover:bg-white/20 rounded-lg transition-all duration-200"
+                      className="p-1.5 lg:p-2 text-white/80 hover:text-white hover:bg-white/20 rounded-lg transition-all duration-200"
                       title="過去のタスクを表示"
                     >
-                      <History size={18} className="lg:w-5 lg:h-5" />
+                      <History size={16} className="lg:w-5 lg:h-5" />
                     </button>
                     <button
                       onClick={handleResetClick}
-                      className="p-2 text-white/80 hover:text-white hover:bg-white/20 rounded-lg transition-all duration-200"
+                      className="p-1.5 lg:p-2 text-white/80 hover:text-white hover:bg-white/20 rounded-lg transition-all duration-200"
                       title="記録をリセット"
                     >
-                      <RefreshCw size={18} className="lg:w-5 lg:h-5" />
+                      <RefreshCw size={16} className="lg:w-5 lg:h-5" />
                     </button>
                   </div>
                 </div>
               </div>
 
-              {/* 統計カード */}
-              <div className="p-4 lg:p-6 space-y-4 lg:space-y-6 flex-1 overflow-y-auto">
+              {/* 統計カード - 縦スクロール完全無効 */}
+              <div className="p-3 lg:p-4 space-y-3 lg:space-y-4 flex-1 overflow-hidden flex flex-col">
                 
-                {/* 統計グリッド */}
-                <div className="grid grid-cols-2 gap-3 lg:gap-4">
-                  <div className="bg-gradient-to-br from-blue-50 to-blue-100 p-3 lg:p-4 rounded-lg border border-blue-200">
+                {/* 統計グリッド - コンパクト化 */}
+                <div className="grid grid-cols-2 gap-2 lg:gap-3 flex-shrink-0">
+                  <div className="bg-gradient-to-br from-blue-50 to-blue-100 p-2 lg:p-3 rounded-lg border border-blue-200">
                     <div className="text-center">
-                      <div className="text-2xl lg:text-3xl mb-1 lg:mb-2">🏆</div>
-                      <div className="font-pixel text-xs lg:text-sm text-blue-600">総クリア数</div>
-                      <div className="font-pixel text-lg lg:text-2xl text-blue-800">{totalCleared}</div>
+                      <div className="text-lg lg:text-2xl mb-1">🏆</div>
+                      <div className="font-pixel text-xs text-blue-600">総クリア数</div>
+                      <div className="font-pixel text-sm lg:text-lg text-blue-800">{totalCleared}</div>
                     </div>
                   </div>
                   
-                  <div className="bg-gradient-to-br from-green-50 to-green-100 p-3 lg:p-4 rounded-lg border border-green-200">
+                  <div className="bg-gradient-to-br from-green-50 to-green-100 p-2 lg:p-3 rounded-lg border border-green-200">
                     <div className="text-center">
-                      <div className="text-2xl lg:text-3xl mb-1 lg:mb-2">⭐</div>
-                      <div className="font-pixel text-xs lg:text-sm text-green-600">現在レベル</div>
-                      <div className="font-pixel text-lg lg:text-2xl text-green-800">Lv.{currentSlime}</div>
+                      <div className="text-lg lg:text-2xl mb-1">⭐</div>
+                      <div className="font-pixel text-xs text-green-600">現在レベル</div>
+                      <div className="font-pixel text-sm lg:text-lg text-green-800">Lv.{currentSlime}</div>
                     </div>
                   </div>
 
-                  <div className="bg-gradient-to-br from-purple-50 to-purple-100 p-3 lg:p-4 rounded-lg border border-purple-200">
+                  <div className="bg-gradient-to-br from-purple-50 to-purple-100 p-2 lg:p-3 rounded-lg border border-purple-200">
                     <div className="text-center">
-                      <div className="text-2xl lg:text-3xl mb-1 lg:mb-2">🔥</div>
-                      <div className="font-pixel text-xs lg:text-sm text-purple-600">今週のクリア</div>
-                      <div className="font-pixel text-lg lg:text-2xl text-purple-800">
+                      <div className="text-lg lg:text-2xl mb-1">🔥</div>
+                      <div className="font-pixel text-xs text-purple-600">今週のクリア</div>
+                      <div className="font-pixel text-sm lg:text-lg text-purple-800">
                         {last7Days.reduce((sum, date) => sum + (clearedTasks[date]?.count || 0), 0)}
                       </div>
                     </div>
                   </div>
 
-                  <div className="bg-gradient-to-br from-orange-50 to-orange-100 p-3 lg:p-4 rounded-lg border border-orange-200">
+                  <div className="bg-gradient-to-br from-orange-50 to-orange-100 p-2 lg:p-3 rounded-lg border border-orange-200">
                     <div className="text-center">
-                      <div className="text-2xl lg:text-3xl mb-1 lg:mb-2">⚡</div>
-                      <div className="font-pixel text-xs lg:text-sm text-orange-600">待機中</div>
-                      <div className="font-pixel text-lg lg:text-2xl text-orange-800">{completedTasksCount}</div>
+                      <div className="text-lg lg:text-2xl mb-1">⚡</div>
+                      <div className="font-pixel text-xs text-orange-600">待機中</div>
+                      <div className="font-pixel text-sm lg:text-lg text-orange-800">{completedTasksCount}</div>
                     </div>
                   </div>
                 </div>
 
-                {/* グラフエリア */}
-                <div className="bg-gray-50 rounded-xl p-4 lg:p-6 border flex-1 min-h-0">
-                  <div className="h-48 lg:h-64 xl:h-80">
+                {/* グラフエリア - 残りスペースを全て使用 */}
+                <div className="bg-gray-50 rounded-xl p-2 lg:p-3 border flex-1 min-h-0">
+                  <div className="h-full min-h-[120px]">
                     <Bar data={chartData} options={chartOptions} />
                   </div>
                 </div>

--- a/src/components/JourneyPage.tsx
+++ b/src/components/JourneyPage.tsx
@@ -229,7 +229,7 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
   return (
     <div className="flex flex-col h-screen bg-slate-50">
       {/* Header */}
-      <header className="bg-royal-blue text-white p-4 shadow-md">
+      <header className="bg-royal-blue text-white p-4 shadow-md flex-shrink-0">
         <div className="container mx-auto flex items-center">
           <button
             onClick={onNavigateToBoard}
@@ -249,13 +249,13 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
         </div>
       </header>
 
-      {/* Main Content */}
-      <main className="flex-1 overflow-y-auto p-6">
-        <div className="container mx-auto max-w-7xl h-full">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 h-full">
+      {/* Main Content - 縦スクロール対応 */}
+      <main className="flex-1 overflow-y-auto">
+        <div className="container mx-auto max-w-7xl p-6">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             
             {/* 左側: スライム主役エリア */}
-            <div className={`${backgroundTheme.bg} rounded-xl overflow-hidden shadow-2xl relative min-h-[600px] lg:min-h-full`}>
+            <div className={`${backgroundTheme.bg} rounded-xl overflow-hidden shadow-2xl relative min-h-[600px]`}>
               
               {/* メインコンテンツ */}
               <div className="relative z-10 flex flex-col h-full p-6 text-center">

--- a/src/components/JourneyPage.tsx
+++ b/src/components/JourneyPage.tsx
@@ -348,9 +348,15 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
             {/* 右側: 統計・グラフエリア */}
             <div className="bg-white rounded-xl shadow-lg overflow-hidden">
               
-              {/* 統計エリアヘッダー - 背景色を明示的に指定 */}
-              <div className="bg-gradient-to-r from-blue-500 to-purple-600 text-white p-6 relative">
-                <div className="flex justify-between items-center relative z-10">
+              {/* 統計エリアヘッダー - インラインスタイルで強制的に背景色を適用 */}
+              <div 
+                className="text-white p-6"
+                style={{
+                  background: 'linear-gradient(to right, #3b82f6, #9333ea)',
+                  backgroundColor: '#3b82f6'
+                }}
+              >
+                <div className="flex justify-between items-center">
                   <h3 className="text-2xl font-pixel text-white">冒険の記録</h3>
                   <div className="flex gap-2">
                     <button

--- a/src/components/JourneyPage.tsx
+++ b/src/components/JourneyPage.tsx
@@ -290,7 +290,7 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
                       <img 
                         src={`/slime_${previousSlime}.jpg`}
                         alt={`Level ${previousSlime} Slime`}
-                        className="w-40 h-40 lg:w-48 lg:h-48 xl:w-56 xl:h-56 object-contain drop-shadow-2xl opacity-50 absolute animate-evolution"
+                        className="w-56 h-56 lg:w-72 lg:h-72 xl:w-80 xl:h-80 object-contain drop-shadow-2xl opacity-50 absolute animate-evolution"
                       />
                     )}
                     
@@ -298,7 +298,7 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
                     <img 
                       src={`/slime_${currentSlime}.jpg`} 
                       alt={`Level ${currentSlime} Slime`}
-                      className={`w-40 h-40 lg:w-48 lg:h-48 xl:w-56 xl:h-56 object-contain drop-shadow-2xl transition-all duration-300 
+                      className={`w-56 h-56 lg:w-72 lg:h-72 xl:w-80 xl:h-80 object-contain drop-shadow-2xl transition-all duration-300 
                                  group-hover:scale-105 ${isEvolving ? 'animate-evolution' : ''} ${slimeAction}`}
                     />
                   </div>

--- a/src/components/JourneyPage.tsx
+++ b/src/components/JourneyPage.tsx
@@ -121,6 +121,7 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
 
   const chartOptions = {
     responsive: true,
+    maintainAspectRatio: false,
     plugins: {
       legend: {
         display: false
@@ -130,7 +131,7 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
         text: '🗓️ 過去7日間のクリア数',
         font: {
           family: "'Press Start 2P', 'DotGothic16', sans-serif",
-          size: 12
+          size: 10
         },
         color: '#374151'
       }
@@ -142,7 +143,7 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
           stepSize: 1,
           font: {
             family: "'Press Start 2P', 'DotGothic16', sans-serif",
-            size: 10
+            size: 8
           }
         },
         grid: {
@@ -153,7 +154,7 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
         ticks: {
           font: {
             family: "'Press Start 2P', 'DotGothic16', sans-serif",
-            size: 10
+            size: 8
           }
         },
         grid: {
@@ -249,26 +250,26 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
         </div>
       </header>
 
-      {/* Main Content - 縦スクロール対応 */}
-      <main className="flex-1 overflow-y-auto">
-        <div className="container mx-auto max-w-7xl p-6">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {/* Main Content - 横並び時は縦スクロール無効、縦並び時は有効 */}
+      <main className="flex-1 lg:overflow-hidden overflow-y-auto">
+        <div className="container mx-auto max-w-7xl p-4 lg:p-6 h-full">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-6 lg:h-full">
             
             {/* 左側: スライム主役エリア */}
-            <div className={`${backgroundTheme.bg} rounded-xl overflow-hidden shadow-2xl relative min-h-[600px]`}>
+            <div className={`${backgroundTheme.bg} rounded-xl overflow-hidden shadow-2xl relative min-h-[500px] lg:h-full flex flex-col`}>
               
               {/* メインコンテンツ */}
-              <div className="relative z-10 flex flex-col h-full p-6 text-center">
+              <div className="relative z-10 flex flex-col h-full p-4 lg:p-6 text-center">
                 
                 {/* ヘッダー情報 */}
-                <div className="flex-shrink-0 mb-6">
-                  <h2 className="text-3xl lg:text-4xl font-pixel text-white drop-shadow-lg mb-2">
+                <div className="flex-shrink-0 mb-4 lg:mb-6">
+                  <h2 className="text-2xl lg:text-3xl xl:text-4xl font-pixel text-white drop-shadow-lg mb-2">
                     Lv.{currentSlime} スライム
                   </h2>
-                  <p className="text-lg lg:text-xl font-pixel text-white/90 drop-shadow-md mb-1">
+                  <p className="text-base lg:text-lg xl:text-xl font-pixel text-white/90 drop-shadow-md mb-1">
                     {backgroundTheme.title}
                   </p>
-                  <p className="text-base lg:text-lg font-pixel text-white/80 drop-shadow-md">
+                  <p className="text-sm lg:text-base xl:text-lg font-pixel text-white/80 drop-shadow-md">
                     {backgroundTheme.scene}の住人
                   </p>
                 </div>
@@ -289,7 +290,7 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
                       <img 
                         src={`/slime_${previousSlime}.jpg`}
                         alt={`Level ${previousSlime} Slime`}
-                        className="w-64 h-64 lg:w-80 lg:h-80 object-contain drop-shadow-2xl opacity-50 absolute animate-evolution"
+                        className="w-48 h-48 lg:w-64 lg:h-64 xl:w-80 xl:h-80 object-contain drop-shadow-2xl opacity-50 absolute animate-evolution"
                       />
                     )}
                     
@@ -297,7 +298,7 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
                     <img 
                       src={`/slime_${currentSlime}.jpg`} 
                       alt={`Level ${currentSlime} Slime`}
-                      className={`w-64 h-64 lg:w-80 lg:h-80 object-contain drop-shadow-2xl transition-all duration-300 
+                      className={`w-48 h-48 lg:w-64 lg:h-64 xl:w-80 xl:h-80 object-contain drop-shadow-2xl transition-all duration-300 
                                  group-hover:scale-105 ${isEvolving ? 'animate-evolution' : ''} ${slimeAction}`}
                     />
                   </div>
@@ -305,21 +306,21 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
                 
                 {/* 進捗情報 */}
                 <div className="flex-shrink-0 w-full max-w-md mx-auto">
-                  <div className="space-y-3 mb-4">
-                    <p className="font-pixel text-xl lg:text-2xl text-white drop-shadow-lg">
+                  <div className="space-y-2 lg:space-y-3 mb-3 lg:mb-4">
+                    <p className="font-pixel text-lg lg:text-xl xl:text-2xl text-white drop-shadow-lg">
                       {totalCleared}個のタスクをクリア！
                     </p>
                     {nextGoal !== Infinity && (
-                      <p className="font-pixel text-sm lg:text-lg text-white/90 drop-shadow-md">
+                      <p className="font-pixel text-xs lg:text-sm xl:text-lg text-white/90 drop-shadow-md">
                         次の進化まで: {nextGoal - totalCleared}個
                       </p>
                     )}
                   </div>
                   
                   {/* 進捗バー */}
-                  <div className="bg-white/30 rounded-full h-3 lg:h-4 backdrop-blur-sm border border-white/40 mb-4">
+                  <div className="bg-white/30 rounded-full h-2 lg:h-3 xl:h-4 backdrop-blur-sm border border-white/40 mb-3 lg:mb-4">
                     <div 
-                      className="bg-gradient-to-r from-yellow-400 to-orange-500 h-3 lg:h-4 rounded-full transition-all duration-500 shadow-inner"
+                      className="bg-gradient-to-r from-yellow-400 to-orange-500 h-2 lg:h-3 xl:h-4 rounded-full transition-all duration-500 shadow-inner"
                       style={{ 
                         width: nextGoal !== Infinity ? `${((totalCleared % (nextGoal === 10 ? 10 : nextGoal === 20 ? 10 : nextGoal === 50 ? 30 : 50)) / (nextGoal === 10 ? 10 : nextGoal === 20 ? 10 : nextGoal === 50 ? 30 : 50)) * 100}%` : '100%'
                       }}
@@ -328,15 +329,15 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
                   
                   {/* 経験値反映ボタン */}
                   {completedTasksCount > 0 && (
-                    <div className="bg-white/20 backdrop-blur-sm border border-white/30 rounded-xl p-4 w-full">
-                      <p className="font-pixel text-sm lg:text-base text-white drop-shadow-md mb-3">
+                    <div className="bg-white/20 backdrop-blur-sm border border-white/30 rounded-xl p-3 lg:p-4 w-full">
+                      <p className="font-pixel text-xs lg:text-sm xl:text-base text-white drop-shadow-md mb-2 lg:mb-3">
                         {completedTasksCount}個の完了タスクがあります
                       </p>
                       <button
                         onClick={handleClaimAllExp}
-                        className="bg-yellow-500 hover:bg-yellow-600 text-white font-pixel px-4 py-2 lg:px-6 lg:py-3 rounded-lg transition-all duration-200 flex items-center gap-2 mx-auto text-sm lg:text-base shadow-lg hover:shadow-xl transform hover:scale-105"
+                        className="bg-yellow-500 hover:bg-yellow-600 text-white font-pixel px-3 py-2 lg:px-4 lg:py-2 xl:px-6 xl:py-3 rounded-lg transition-all duration-200 flex items-center gap-2 mx-auto text-xs lg:text-sm xl:text-base shadow-lg hover:shadow-xl transform hover:scale-105"
                       >
-                        <Star size={16} className="lg:w-5 lg:h-5" />
+                        <Star size={14} className="lg:w-4 lg:h-4 xl:w-5 xl:h-5" />
                         経験値を反映する
                       </button>
                     </div>
@@ -346,80 +347,80 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
             </div>
 
             {/* 右側: 統計・グラフエリア */}
-            <div className="bg-white rounded-xl shadow-lg overflow-hidden">
+            <div className="bg-white rounded-xl shadow-lg overflow-hidden lg:h-full flex flex-col">
               
               {/* 統計エリアヘッダー - インラインスタイルで強制的に背景色を適用 */}
               <div 
-                className="text-white p-6"
+                className="text-white p-4 lg:p-6 flex-shrink-0"
                 style={{
                   background: 'linear-gradient(to right, #3b82f6, #9333ea)',
                   backgroundColor: '#3b82f6'
                 }}
               >
                 <div className="flex justify-between items-center">
-                  <h3 className="text-2xl font-pixel text-white">冒険の記録</h3>
+                  <h3 className="text-xl lg:text-2xl font-pixel text-white">冒険の記録</h3>
                   <div className="flex gap-2">
                     <button
                       onClick={() => setShowPastTasks(true)}
                       className="p-2 text-white/80 hover:text-white hover:bg-white/20 rounded-lg transition-all duration-200"
                       title="過去のタスクを表示"
                     >
-                      <History size={20} />
+                      <History size={18} className="lg:w-5 lg:h-5" />
                     </button>
                     <button
                       onClick={handleResetClick}
                       className="p-2 text-white/80 hover:text-white hover:bg-white/20 rounded-lg transition-all duration-200"
                       title="記録をリセット"
                     >
-                      <RefreshCw size={20} />
+                      <RefreshCw size={18} className="lg:w-5 lg:h-5" />
                     </button>
                   </div>
                 </div>
               </div>
 
               {/* 統計カード */}
-              <div className="p-6 space-y-6">
+              <div className="p-4 lg:p-6 space-y-4 lg:space-y-6 flex-1 overflow-y-auto">
                 
                 {/* 統計グリッド */}
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="bg-gradient-to-br from-blue-50 to-blue-100 p-4 rounded-lg border border-blue-200">
+                <div className="grid grid-cols-2 gap-3 lg:gap-4">
+                  <div className="bg-gradient-to-br from-blue-50 to-blue-100 p-3 lg:p-4 rounded-lg border border-blue-200">
                     <div className="text-center">
-                      <div className="text-3xl mb-2">🏆</div>
-                      <div className="font-pixel text-sm text-blue-600">総クリア数</div>
-                      <div className="font-pixel text-2xl text-blue-800">{totalCleared}</div>
+                      <div className="text-2xl lg:text-3xl mb-1 lg:mb-2">🏆</div>
+                      <div className="font-pixel text-xs lg:text-sm text-blue-600">総クリア数</div>
+                      <div className="font-pixel text-lg lg:text-2xl text-blue-800">{totalCleared}</div>
                     </div>
                   </div>
                   
-                  <div className="bg-gradient-to-br from-green-50 to-green-100 p-4 rounded-lg border border-green-200">
+                  <div className="bg-gradient-to-br from-green-50 to-green-100 p-3 lg:p-4 rounded-lg border border-green-200">
                     <div className="text-center">
-                      <div className="text-3xl mb-2">⭐</div>
-                      <div className="font-pixel text-sm text-green-600">現在レベル</div>
-                      <div className="font-pixel text-2xl text-green-800">Lv.{currentSlime}</div>
+                      <div className="text-2xl lg:text-3xl mb-1 lg:mb-2">⭐</div>
+                      <div className="font-pixel text-xs lg:text-sm text-green-600">現在レベル</div>
+                      <div className="font-pixel text-lg lg:text-2xl text-green-800">Lv.{currentSlime}</div>
                     </div>
                   </div>
 
-                  <div className="bg-gradient-to-br from-purple-50 to-purple-100 p-4 rounded-lg border border-purple-200">
+                  <div className="bg-gradient-to-br from-purple-50 to-purple-100 p-3 lg:p-4 rounded-lg border border-purple-200">
                     <div className="text-center">
-                      <div className="text-3xl mb-2">🔥</div>
-                      <div className="font-pixel text-sm text-purple-600">今週のクリア</div>
-                      <div className="font-pixel text-2xl text-purple-800">
+                      <div className="text-2xl lg:text-3xl mb-1 lg:mb-2">🔥</div>
+                      <div className="font-pixel text-xs lg:text-sm text-purple-600">今週のクリア</div>
+                      <div className="font-pixel text-lg lg:text-2xl text-purple-800">
                         {last7Days.reduce((sum, date) => sum + (clearedTasks[date]?.count || 0), 0)}
                       </div>
                     </div>
                   </div>
 
-                  <div className="bg-gradient-to-br from-orange-50 to-orange-100 p-4 rounded-lg border border-orange-200">
+                  <div className="bg-gradient-to-br from-orange-50 to-orange-100 p-3 lg:p-4 rounded-lg border border-orange-200">
                     <div className="text-center">
-                      <div className="text-3xl mb-2">⚡</div>
-                      <div className="font-pixel text-sm text-orange-600">待機中</div>
-                      <div className="font-pixel text-2xl text-orange-800">{completedTasksCount}</div>
+                      <div className="text-2xl lg:text-3xl mb-1 lg:mb-2">⚡</div>
+                      <div className="font-pixel text-xs lg:text-sm text-orange-600">待機中</div>
+                      <div className="font-pixel text-lg lg:text-2xl text-orange-800">{completedTasksCount}</div>
                     </div>
                   </div>
                 </div>
 
                 {/* グラフエリア */}
-                <div className="bg-gray-50 rounded-xl p-6 border">
-                  <div className="h-80">
+                <div className="bg-gray-50 rounded-xl p-4 lg:p-6 border flex-1 min-h-0">
+                  <div className="h-48 lg:h-64 xl:h-80">
                     <Bar data={chartData} options={chartOptions} />
                   </div>
                 </div>

--- a/src/components/JourneyPage.tsx
+++ b/src/components/JourneyPage.tsx
@@ -348,10 +348,10 @@ const JourneyPage: React.FC<JourneyPageProps> = ({ onNavigateToBoard }) => {
             {/* 右側: 統計・グラフエリア */}
             <div className="bg-white rounded-xl shadow-lg overflow-hidden">
               
-              {/* 統計エリアヘッダー - 常に表示 */}
-              <div className="bg-gradient-to-r from-blue-500 to-purple-600 text-white p-6">
-                <div className="flex justify-between items-center">
-                  <h3 className="text-2xl font-pixel">冒険の記録</h3>
+              {/* 統計エリアヘッダー - 背景色を明示的に指定 */}
+              <div className="bg-gradient-to-r from-blue-500 to-purple-600 text-white p-6 relative">
+                <div className="flex justify-between items-center relative z-10">
+                  <h3 className="text-2xl font-pixel text-white">冒険の記録</h3>
                   <div className="flex gap-2">
                     <button
                       onClick={() => setShowPastTasks(true)}

--- a/src/components/PastTasksModal.tsx
+++ b/src/components/PastTasksModal.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
-import { X, Calendar } from 'lucide-react';
+import { X, Calendar, RotateCcw } from 'lucide-react';
 import { useJourneyStore } from '../store/useJourneyStore';
+import { useTaskStore } from '../store/useTaskStore';
+import { useAudioStore } from '../store/useAudioStore';
+import { playAddTaskSound } from '../utils/audio';
 
 interface PastTasksModalProps {
   isOpen: boolean;
@@ -8,7 +11,9 @@ interface PastTasksModalProps {
 }
 
 const PastTasksModal: React.FC<PastTasksModalProps> = ({ isOpen, onClose }) => {
-  const { clearedTasks } = useJourneyStore();
+  const { clearedTasks, removeClearedTask } = useJourneyStore();
+  const { addTask } = useTaskStore();
+  const { getVolumeValue } = useAudioStore();
 
   if (!isOpen) return null;
 
@@ -20,6 +25,17 @@ const PastTasksModal: React.FC<PastTasksModalProps> = ({ isOpen, onClose }) => {
       day: 'numeric',
       weekday: 'long'
     });
+  };
+
+  const handleRestoreTask = (date: string, taskIndex: number, task: any) => {
+    // タスクをクリアボードに復元
+    addTask(task.title, task.description || '', 'backlog');
+    
+    // 過去タスクから削除
+    removeClearedTask(date, taskIndex);
+    
+    // 効果音再生
+    playAddTaskSound();
   };
 
   // Sort dates in descending order
@@ -69,16 +85,30 @@ const PastTasksModal: React.FC<PastTasksModalProps> = ({ isOpen, onClose }) => {
                     {record.tasks.map((task, index) => (
                       <div 
                         key={`${date}-${index}`}
-                        className="bg-white border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow duration-200"
+                        className="bg-white border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow duration-200 group"
                       >
-                        <h4 className="font-pixel text-gray-900 mb-2">
-                          {task.title}
-                        </h4>
-                        {task.description && (
-                          <p className="text-gray-600 text-sm whitespace-pre-wrap pl-4 border-l-2 border-gray-200">
-                            {task.description}
-                          </p>
-                        )}
+                        <div className="flex items-start justify-between">
+                          <div className="flex-1">
+                            <h4 className="font-pixel text-gray-900 mb-2">
+                              {task.title}
+                            </h4>
+                            {task.description && (
+                              <p className="text-gray-600 text-sm whitespace-pre-wrap pl-4 border-l-2 border-gray-200">
+                                {task.description}
+                              </p>
+                            )}
+                          </div>
+                          
+                          {/* 復元ボタン */}
+                          <button
+                            onClick={() => handleRestoreTask(date, index, task)}
+                            className="ml-4 p-2 text-blue-500 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-all duration-200 opacity-0 group-hover:opacity-100 flex items-center gap-1"
+                            title="クリアボードに戻す"
+                          >
+                            <RotateCcw size={16} />
+                            <span className="text-xs font-medium">復元</span>
+                          </button>
+                        </div>
                       </div>
                     ))}
                   </div>
@@ -86,6 +116,12 @@ const PastTasksModal: React.FC<PastTasksModalProps> = ({ isOpen, onClose }) => {
               ))}
             </div>
           )}
+        </div>
+
+        <div className="p-4 border-t border-gray-200 bg-gray-50 text-center">
+          <p className="text-xs text-gray-500">
+            💡 各タスクにマウスを合わせると復元ボタンが表示されます
+          </p>
         </div>
       </div>
     </div>

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -51,7 +51,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onEdit, onDelete, onCopy }) =
       className="bg-white/95 backdrop-blur-sm border border-gray-200/60 p-4 rounded-xl shadow-md mb-3 cursor-grab active:cursor-grabbing transition-all duration-300 hover:shadow-xl hover:translate-y-[-3px] hover:scale-[1.02] group"
     >
       <div className="flex justify-between items-start">
-        <h3 className="font-pixel text-gray-900 mb-2 leading-relaxed flex-1 pr-2 break-words overflow-wrap-anywhere">
+        <h3 className="font-pixel text-gray-900 mb-2 leading-relaxed flex-1 pr-2 break-words overflow-wrap-anywhere word-break">
           {task.title}
         </h3>
         <div className="flex space-x-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex-shrink-0">
@@ -76,7 +76,7 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onEdit, onDelete, onCopy }) =
         </div>
       </div>
       {task.description && (
-        <p className="font-pixel text-gray-700 text-sm mt-2 leading-relaxed opacity-80 whitespace-pre-wrap break-words">
+        <p className="font-pixel text-gray-700 text-sm mt-2 leading-relaxed opacity-80 whitespace-pre-wrap break-words word-break">
           {task.description}
         </p>
       )}

--- a/src/index.css
+++ b/src/index.css
@@ -201,3 +201,10 @@ html, body {
 .animate-slime-heart {
   animation: slime-heart 0.5s ease-in-out;
 }
+
+/* 長いテキストの改行対応 */
+.word-break {
+  word-break: break-word;
+  overflow-wrap: break-word;
+  hyphens: auto;
+}

--- a/src/store/useJourneyStore.ts
+++ b/src/store/useJourneyStore.ts
@@ -14,6 +14,7 @@ interface DailyRecord {
 interface JourneyStore {
   clearedTasks: Record<string, DailyRecord>;
   addClearedTask: (task: Task) => void;
+  removeClearedTask: (date: string, taskIndex: number) => void;
   resetJourney: () => void;
   loadFromLocalStorage: () => void;
   saveToLocalStorage: () => void;
@@ -41,6 +42,40 @@ export const useJourneyStore = create<JourneyStore>((set, get) => ({
         clearedTasks: {
           ...state.clearedTasks,
           [today]: updatedRecord
+        }
+      };
+    });
+
+    get().saveToLocalStorage();
+  },
+
+  removeClearedTask: (date: string, taskIndex: number) => {
+    set(state => {
+      const record = state.clearedTasks[date];
+      if (!record || taskIndex < 0 || taskIndex >= record.tasks.length) {
+        return state;
+      }
+
+      const newTasks = [...record.tasks];
+      newTasks.splice(taskIndex, 1);
+
+      const updatedRecord = {
+        count: Math.max(0, record.count - 1),
+        tasks: newTasks
+      };
+
+      // If no tasks left for this date, remove the entire record
+      if (updatedRecord.count === 0) {
+        const { [date]: removed, ...remainingTasks } = state.clearedTasks;
+        return {
+          clearedTasks: remainingTasks
+        };
+      }
+
+      return {
+        clearedTasks: {
+          ...state.clearedTasks,
+          [date]: updatedRecord
         }
       };
     });


### PR DESCRIPTION
## 🚀 機能とUI/UXの改善

このプルリクエストでは、レイアウトの最適化、テキスト処理、およびクリア済みタスクの復元機能の追加に焦点を当て、アプリケーション全体のUI/UXを改善します。

### ✨ 主な変更点

#### 1. Kanbanボードのレイアウト最適化
- **問題点**: 以前のKanbanボードでは、長いタスクタイトルが横スクロールを引き起こし、固定された最小幅が様々な画面サイズでのレイアウトの一貫性を損なっていました。
- **解決策**:
    - `src/components/Board.tsx`: 横スクロールと固定最小幅を無効にするため、`overflow-x-auto`と`min-w-max`を削除しました。より良い間隔とコンパクトなレイアウトのために、`justify-center`を`gap-4`と`p-4`に変更しました。
    - `src/components/Column.tsx`: カラムの幅を固定の`min-w-[280px] max-w-[360px]`から`flex-1`に変更し、画面全体で均等に配分されるようにしました。`min-w-0`を追加し、フレックスコンテナ内でカラムが適切に縮小できるようにしました。カラムタイトルがオーバーフローしないように`truncate`を適用し、ヘッダー要素（絵文字、タイトル、追加ボタン）が縮小しないように`flex-shrink-0`を適用しました。
    - `src/components/TaskCard.tsx`: タスクのタイトルと説明に`word-break`クラスを適用し、長いテキストがカード内で適切に折り返され、横方向のオーバーフローを防ぐようにしました。
    - `src/index.css`: 長い単語を処理し、オーバーフローを防ぐために`word-break` CSSプロパティを定義しました。

#### 2. 旅の記録画面のレイアウトとレスポンシブ対応
- **問題点**: 旅の記録画面（スライムダッシュボード）は、特に大きな画面で横並びに表示される際に縦スクロールの問題があり、一部の要素のサイズが最適ではありませんでした。
- **解決策**:
    - `src/components/JourneyPage.tsx`: `main`要素を`lg:overflow-hidden overflow-y-auto`に調整し、横並びレイアウト時（大画面）には縦スクロールを無効にし、小画面では有効にしました。パディングとギャップを削減し（`p-3 lg:p-4`、`gap-3 lg:gap-4`）、よりコンパクトなレイアウトにしました。フォントサイズ（例: `text-xl lg:text-2xl xl:text-3xl`を`text-lg lg:text-xl xl:text-2xl`に）と要素サイズ（スライム画像`w-56 h-56 lg:w-72 lg:h-72 xl:w-80 xl:h-80`に）を縮小し、すべてのコンテンツが縦スクロールなしでビューポート内に収まるようにしました。チャートオプション（`maintainAspectRatio: false`、ラベルのフォントサイズを小さく）を調整し、利用可能なスペース内でチャートが適切にスケーリングされるようにしました。統計ヘッダーにインラインスタイルで背景色を適用し、一貫した外観を確保しました。

#### 3. 過去タスクモーダルからのタスク復元
- **問題点**: ユーザーは過去のクリア済みタスクを閲覧できましたが、アクティブなボードに復元する方法がありませんでした。
- **解決策**:
    - `src/components/PastTasksModal.tsx`: モーダル内の各クリア済みタスクの横に「復元」ボタン（`RotateCcw`アイコン）を追加しました。このボタンは個々のタスクにマウスオーバーすると表示されます。選択したタスクを`backlog`カラムに戻し、`clearedTasks`履歴から削除する`handleRestoreTask`関数を実装しました。
    - `src/store/useJourneyStore.ts`: `clearedTasks`履歴から特定のタスクを削除できるように、新しいアクション`removeClearedTask(date: string, taskIndex: number)`を追加しました。
    - `src/utils/audio.ts`: タスクが復元されたときに`playAddTaskSound`がトリガーされるようにしました。
